### PR TITLE
Add short-hands for all HTTP methods defined in RFC 9110 and RFC 5789

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, require the library:
 (:require [java-http-clj.core :as http])
 ```
 
-The most common HTTP methods (GET, POST, PUT, HEAD, DELETE) have a function of the same name. This function takes three arguments (where the last two are optional): a URL, a request and an options map (refer to [send](https://schmee.github.io/java-http-clj/java-http-clj.core.html#var-send) docs for details).
+The most common HTTP methods (GET, POST, PUT, HEAD, DELETE, CONNECT, OPTIONS, TRACE, PATCH) have a function of the same name. This function takes three arguments (where the last two are optional): a URL, a request and an options map (refer to [send](https://schmee.github.io/java-http-clj/java-http-clj.core.html#var-send) docs for details).
 
 - GET requests
 

--- a/src/java_http_clj/util.clj
+++ b/src/java_http_clj/util.clj
@@ -16,4 +16,4 @@
   `(reify Function
     (~'apply [_# x#] (~f x#))))
 
-(def shorthands [:get :head :post :put :delete])
+(def shorthands [:get :head :post :put :delete :connect :options :trace :patch])


### PR DESCRIPTION
Not sure if this is something you intentionally left out, but I think it would be useful to have short-hands for all the common HTTP methods, particularly those defined in RFC 9110 and RFC 5789.

RFC 9110: https://www.rfc-editor.org/rfc/rfc9110#name-method-definitions
  - GET, HEAD, POST, PUT, DELETE, **CONNECT**, **OPTIONS**, **TRACE**

RFC 5789: https://rfc-editor.org/rfc/rfc5789
  - **PATCH**